### PR TITLE
fixed string literal in hole classNames

### DIFF
--- a/whack-a-mole/views/index.pug
+++ b/whack-a-mole/views/index.pug
@@ -6,5 +6,5 @@ block content
   button Start!
   div.game
     each val in [1, 2, 3, 4, 5, 6]
-      div(class="hole hole#{val}")
+      div(class=`hole hole${val}`)
         div.mole


### PR DESCRIPTION
noticed a typo on the pug file that was causing bad classnames